### PR TITLE
Add `ffmpeg` to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# Stage 1 - Python dependencies
+# Use Python 3.12 slim as base image
 FROM python:3.12-slim AS python-deps
-
 
 # ARG APP_VERSION, will be set during build by github actions
 ARG APP_VERSION=0.0.0-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY ./requirements.txt /app/requirements.txt
 RUN python -m pip install --no-cache-dir --disable-pip-version-check \
     --upgrade -r /app/requirements.txt
 
-
 # Install tzdata, gosu and set timezone
 RUN apt-get update && apt-get install -y tzdata gosu curl && \
     ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
@@ -38,14 +37,12 @@ COPY . /app
 # Set the python path
 ENV PYTHONPATH=/app
 
-# Copy the entrypoint script and make it executable
-COPY ./scripts/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Make the scripts inside /app/scripts executable
+RUN chmod +x /app/scripts/*.sh
 
-# Copy startup script and make it executable
-COPY ./scripts/start.sh /app/start.sh
-RUN chmod +x /app/start.sh
+# Install ffmpeg using install_ffmpeg.sh script
+RUN /app/scripts/install_ffmpeg.sh
 
 # Run entrypoint script to create directories, set permissions and timezone \
 # and start the application as appuser
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -86,7 +86,7 @@ chown -R "$APPUSER":"$APPGROUP" "$APP_DATA_DIR"
 
 # Switch to the non-root user and execute the command
 echo "Switching to user '$APPUSER' and starting the application"
-exec gosu "$APPUSER" bash -c /app/start.sh
+exec gosu "$APPUSER" bash -c /app/scripts/start.sh
 
 # DO NOT ADD ANY OTHER COMMANDS HERE! THEY WON'T BE EXECUTED!
 # Instead add them in the start.sh script

--- a/scripts/install_ffmpeg.sh
+++ b/scripts/install_ffmpeg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+# Function to install ffmpeg for Debian-based systems
+install_ffmpeg_debian() {
+    # Get the architecture of the system
+    ARCH=$(dpkg --print-architecture)
+    if [ "$ARCH" == "amd64" ]; then
+        # Download the latest ffmpeg build for amd64
+        FFMPEG_URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+    elif [ "$ARCH" == "arm64" ] || [ "$ARCH" == "aarch64" ]; then
+        # Download the latest ffmpeg build for arm64
+        FFMPEG_URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz"
+    else
+        # If the architecture is not supported, install ffmpeg using apt
+        echo "Unsupported architecture: $ARCH, Installing ffmpeg manually"
+        apt-get install -y ffmpeg
+        mv /usr/bin/ff* /usr/local/bin/
+        exit 0
+    fi
+
+    # Install the required dependencies
+    apt-get update && apt-get install -y curl xz-utils
+    # Download and install ffmpeg
+    echo "Downloading ffmpeg for $ARCH"
+    curl -L -o /tmp/ffmpeg.tar.xz "$FFMPEG_URL"
+    mkdir /tmp/ffmpeg
+    tar -xf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1
+    mv /tmp/ffmpeg/bin/* /usr/local/bin/
+    rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg
+}
+
+# Detect the OS and install ffmpeg accordingly
+if [ -f /etc/debian_version ]; then
+    install_ffmpeg_debian
+else
+    echo "Unsupported OS"
+    exit 1
+fi


### PR DESCRIPTION
Add `ffmpeg` to container.

`./scripts/install_ffmpeg.sh` can be used outside container to install `ffmpeg` (patched version of from `yt-dlp`) in most Linux OS.